### PR TITLE
Adding support for Dark Mode.

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -6,6 +6,7 @@
 
 	let WORDLENGTH = 5;
 	let showInstructions = false;
+	let darkMode = false;
 
 	let relevanceScores = {};
 	let filteredAnswers = wordle_answers;
@@ -96,6 +97,13 @@
 		}
 		return "empty";
 	}
+	function isDarkModeOn(state) {
+		if (state === 1) {
+			return "darkMode";
+		} else {
+			return "";
+		}
+	}
 
 </script>
 
@@ -111,8 +119,22 @@
 				</game-icon>
 			</button>
 		</div>
-		<div class="title"> UNWORDLE </div>
-		<div class="menu">
+		<div class="title {darkMode ? 'darkModeText': ''}"> UNWORDLE </div>
+		<div class="darkMode">
+			<input
+				type="checkbox"
+				id="darkMode"
+				on:click={() => { 
+					darkMode = !darkMode;
+					const body = document.getElementsByTagName("body");
+					if (darkMode) {
+						body[0].style.background="#121213";
+					} else {
+						body[0].style.background="#FFFFFF";
+					}
+				}}
+			/>
+			<label style="display:inline" class="{darkMode ? 'darkModeText': ''} ">Dark Mode</label>
 		</div>
 	</header>
 	<div id="board-container">
@@ -134,10 +156,10 @@
 				</game-row>
 			{/each}
 			<div class="suggestions">
-				<div class="suggestion" id="title">Best words to guess next</div>
+				<div class="suggestion {darkMode ? 'darkModeText': ''}" id="title">Best words to guess next</div>
 				{#each Object.entries(relevanceScores) as [word, score], index}
 					{#if index < 10}
-						<div class="suggestion">{index+1}. {word}</div>
+						<div class="suggestion {darkMode ? 'darkModeText': ''}">{index+1}. {word}</div>
 					{/if}
 				{/each}
 			</div>
@@ -415,6 +437,13 @@
 		text-transform: uppercase;
 		user-select: none;
 		opacity: 1;
+	}
+	.darkModeBackground {
+		background-color: #121213;
+	}
+
+	.darkModeText {
+		color: #d7dadc;
 	}
 
 	:root {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -97,13 +97,6 @@
 		}
 		return "empty";
 	}
-	function isDarkModeOn(state) {
-		if (state === 1) {
-			return "darkMode";
-		} else {
-			return "";
-		}
-	}
 
 </script>
 


### PR DESCRIPTION
I love this webpage. Thank you so much for creating it.

All I thought was, we could add a dark mode toggle to it and that is exactly what I did in this Pull Request.

Adding a screenshot for your reference.

The color scheme is similar to the wordle webpage. 

<img width="1788" alt="Screenshot 2022-01-30 at 3 38 49 AM" src="https://user-images.githubusercontent.com/23290433/151679104-91c76544-cc5b-4bf8-81dc-a61eff3fa8d9.png">

<img width="1788" alt="Screenshot 2022-01-30 at 3 39 05 AM" src="https://user-images.githubusercontent.com/23290433/151679110-a8f71d99-ec3b-4e53-b24b-b899ab18c426.png">


